### PR TITLE
0.7.0

### DIFF
--- a/Annotation/Resource.php
+++ b/Annotation/Resource.php
@@ -11,4 +11,29 @@ class Resource
      * @var string
      */
     public $name;
+
+    /**
+     * @var bool
+     */
+    public $search = true;
+
+    /**
+     * @var bool
+     */
+    public $create = true;
+
+    /**
+     * @var bool
+     */
+    public $update = true;
+
+    /**
+     * @var bool
+     */
+    public $delete = true;
+    
+    /**
+     * @var bool
+     */
+    public $partialUpdate = true;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+CHANGELOG
+===================
+
+This changelog references the relevant changes that have been made to LemonRestBundle starting with version 0.7.
+
+To get the diff for a specific change, go to https://github.com/stanlemon/rest-bundle/commit/XXX where XXX is the change hash
+To get the diff between two versions, go to https://github.com/stanlemon/rest-bundle/compare/0.7.0...master
+
+* 0.7.0 (2015-02-28)
+ * BC Default to plural resource names, this means if you didn't explicit name your object your endpoints will change. For example /api/post -> /api/posts, you can override this behavior by manually configuring the name on the object.
+ * BC Added a first class definition object, which is used by the object registry. The object registry methods changed during this refactor. This definition class will allow for better storage of configuration than the simple arrays that were originally being passed around.
+ * Added the option to map a directory of entities. This allows for you to use LemonRestBundle with a non-automapped directory of Doctrine entities.
+ * Added the option to configure method types for an object, in other words you can now enable 'post' for an object and disable 'delete'. There are attributes on the annotation to support this, and it can be handled manually when working directly with the object registry.
+ * Added support for posting an id to a relation to load the mapped relation, in other words a comment can be posted with a numerical value for property post and this will become the appropriate Post instance.

--- a/Controller/IndexController.php
+++ b/Controller/IndexController.php
@@ -62,10 +62,10 @@ class IndexController
 
         $data = array();
 
-        foreach ($this->registry->getClasses() as $name => $class) {
-            $data[$name . '_url'] = $this->router->generate(
+        foreach ($this->registry->all() as $definition) {
+            $data[$definition->getName() . '_url'] = $this->router->generate(
                 'lemon_rest_list',
-                array('resource' => $name),
+                array('resource' => $definition->getName()),
                 RouterInterface::ABSOLUTE_URL
             );
         }

--- a/DependencyInjection/Compiler/RegisterMappingsPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingsPass.php
@@ -1,9 +1,12 @@
 <?php
 namespace Lemon\RestBundle\DependencyInjection\Compiler;
 
-use Lemon\RestBundle\Object\Definition;
+use Doctrine\Common\Inflector\Inflector;
+use Lemon\RestBundle\Annotation\Resource;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
 
 class RegisterMappingsPass implements CompilerPassInterface
 {
@@ -12,27 +15,90 @@ class RegisterMappingsPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $registry = $container->getDefinition('lemon_rest.object_registry');
-
         $mappings = $container->getParameter('lemon_rest_mappings');
 
         foreach ($mappings as $mapping) {
-            if (!class_exists($mapping['class'])) {
-                throw new \RuntimeException(sprintf("Class \"%s\" does not exist", $mapping['class']));
+            if (isset($mapping['dir']) && isset($mapping['prefix'])) {
+                $this->mapDirectory($container, $mapping['dir'], $mapping['prefix']);
+            } elseif (isset($mapping['class']) && isset($mapping['name'])) {
+                $this->mapClass($container, $mapping['class'], $mapping['name']);
+            } else {
+                throw new \RuntimeException("Invalid mapping configuration!");
             }
-
-            $definition = new Definition(
-                $mapping['name'],
-                $mapping['class']
-            );
-            $definition = new Definition('Lemon\RestBundle\Object\Definition', array(
-                $mapping['name'],
-                $mapping['class']
-            ));
-
-            $container->setDefinition('lemon_rest.object_resources.' . $mapping['name'], $definition);
-
-            $registry->addMethodCall('addClass', array($definition));
         }
+    }
+
+    protected function mapDirectory(ContainerBuilder $container, $dir, $prefix)
+    {
+        if (!is_dir($dir)) {
+            throw new \RuntimeException(sprintf("Invalid directory %s", $dir));
+        }
+
+        $reader   = $container->get('annotation_reader');
+        $registry = $container->getDefinition('lemon_rest.object_registry');
+
+        $finder = new Finder();
+
+        $iterator = $finder
+            ->files()
+            ->name('*.php')
+            ->in($dir)
+        ;
+
+        if (substr($prefix, -1, 1) !== "\\") {
+            $prefix .= "\\";
+        }
+
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            // Translate the directory path from our starting namespace forward
+            $expandedNamespace = substr($file->getPath(), strlen($dir) + 1);
+
+            // If we are in a sub namespace add a trailing separation
+            $expandedNamespace = $expandedNamespace === false ? '' : $expandedNamespace . '\\';
+
+            $className = $prefix . $expandedNamespace .  $file->getBasename('.php');
+
+            if (class_exists($className)) {
+                $reflectionClass = new \ReflectionClass($className);
+
+                foreach ($reader->getClassAnnotations($reflectionClass) as $annotation) {
+                    if ($annotation instanceof Resource) {
+                        $name = $annotation->name ?: Inflector::pluralize(
+                            lcfirst($reflectionClass->getShortName())
+                        );
+
+                        $definition = new Definition('Lemon\RestBundle\Object\Definition', array(
+                            $name,
+                            $className,
+                            $annotation->search,
+                            $annotation->create,
+                            $annotation->update,
+                            $annotation->delete,
+                            $annotation->partialUpdate
+                        ));
+
+                        $container->setDefinition('lemon_rest.object_resources.' . $name, $definition);
+
+                        $registry->addMethodCall('add', array($definition));
+                    }
+                }
+            }
+        }
+    }
+
+    protected function mapClass(ContainerBuilder$container, $class, $name)
+    {
+        // These are explicit name -> class mappings
+        if (!class_exists($class)) {
+            throw new \RuntimeException(sprintf("Class \"%s\" does not exist", $class));
+        }
+
+        $definition = new Definition('Lemon\RestBundle\Object\Definition', array($name, $class));
+
+        $container->setDefinition('lemon_rest.object_resources.' . $name, $definition);
+
+        $registry = $container->getDefinition('lemon_rest.object_registry');
+        $registry->addMethodCall('add', array($definition));
     }
 }

--- a/DependencyInjection/Compiler/RegisterMappingsPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingsPass.php
@@ -1,6 +1,7 @@
 <?php
 namespace Lemon\RestBundle\DependencyInjection\Compiler;
 
+use Lemon\RestBundle\Object\Definition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -20,7 +21,18 @@ class RegisterMappingsPass implements CompilerPassInterface
                 throw new \RuntimeException(sprintf("Class \"%s\" does not exist", $mapping['class']));
             }
 
-            $registry->addMethodCall('addClass', array($mapping['name'], $mapping['class']));
+            $definition = new Definition(
+                $mapping['name'],
+                $mapping['class']
+            );
+            $definition = new Definition('Lemon\RestBundle\Object\Definition', array(
+                $mapping['name'],
+                $mapping['class']
+            ));
+
+            $container->setDefinition('lemon_rest.object_resources.' . $mapping['name'], $definition);
+
+            $registry->addMethodCall('addClass', array($definition));
         }
     }
 }

--- a/DependencyInjection/Compiler/RegisterResourcePass.php
+++ b/DependencyInjection/Compiler/RegisterResourcePass.php
@@ -66,7 +66,7 @@ class RegisterResourcePass implements CompilerPassInterface
 
                                 $container->setDefinition('lemon_rest.object_resources.' . $name, $definition);
 
-                                $registry->addMethodCall('addClass', array($definition));
+                                $registry->addMethodCall('add', array($definition));
                             }
                         }
                     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('mappings')
                     ->prototype('array')
                         ->children()
+                            ->scalarNode('dir')->end()
+                            ->scalarNode('prefix')->end()
                             ->scalarNode('name')->end()
                             ->scalarNode('class')->end()
                         ->end()

--- a/Object/Definition.php
+++ b/Object/Definition.php
@@ -1,0 +1,87 @@
+<?php
+namespace Lemon\RestBundle\Object;
+
+class Definition
+{
+    protected $name;
+    
+    protected $class;
+    
+    /**
+     * @var bool
+     */
+    protected $search = true;
+
+    /**
+     * @var bool
+     */
+    protected $create = true;
+
+    /**
+     * @var bool
+     */
+    protected $update = true;
+
+    /**
+     * @var bool
+     */
+    protected $delete = true;
+    
+    /**
+     * @var bool
+     */
+    protected $partialUpdate = true;
+
+    public function __construct(
+        $name,
+        $class,
+        $search = true,
+        $create = true,
+        $update = true,
+        $delete = true,
+        $partialUpdate = true
+    ) {
+        $this->name = $name;
+        $this->class = $class;
+        $this->search = $search;
+        $this->create = $create;
+        $this->update = $update;
+        $this->delete = $delete;
+        $this->partialUpdate = $partialUpdate;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+    
+    public function getClass()
+    {
+        return $this->class;
+    }
+    
+    public function canSearch()
+    {
+        return $this->search;
+    }
+    
+    public function canCreate()
+    {
+        return $this->create;
+    }
+    
+    public function canUpdate()
+    {
+        return $this->update;
+    }
+    
+    public function canDelete()
+    {
+        return $this->delete;
+    }
+    
+    public function canPartialUpdate()
+    {
+        return $this->partialUpdate;
+    }
+}

--- a/Object/Exception/UnsupportedMethodException.php
+++ b/Object/Exception/UnsupportedMethodException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Lemon\RestBundle\Object\Exception;
+
+class UnsupportedMethodException extends \RuntimeException
+{
+    public function __construct($message = "Method not supported", $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/Object/Manager.php
+++ b/Object/Manager.php
@@ -80,7 +80,7 @@ class Manager implements ManagerInterface
         $metadata = $this->getManager()->getClassMetadata($this->getClass());
 
         foreach ($criteria as $key => $value) {
-            if ($metadata->hasField($key)) {
+            if ($metadata->hasField($key) || $metadata->hasAssociation($key)) {
                 if ($metadata->getTypeOfField($key) == 'string') {
                     $qb->andWhere('o.' . $key . ' LIKE :' . $key);
                     $qb->setParameter($key, '%' . $value . '%');

--- a/Object/Manager.php
+++ b/Object/Manager.php
@@ -8,27 +8,28 @@ use Lemon\RestBundle\Event\PreSearchEvent;
 use Lemon\RestBundle\Event\RestEvents;
 use Lemon\RestBundle\Model\SearchResults;
 use Lemon\RestBundle\Object\Exception\NotFoundException;
+use Lemon\RestBundle\Object\Exception\UnsupportedMethodException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Manager implements ManagerInterface
 {
     protected $doctrine;
     protected $eventDispatcher;
-    protected $class;
+    protected $objectDefinition;
 
     /**
      * @param Doctrine $doctrine
      * @param EventDispatcher $eventDispatcher
-     * @param string $class
+     * @param Definition $objectDefinition
      */
     public function __construct(
         Doctrine $doctrine,
         EventDispatcher $eventDispatcher,
-        $class
+        Definition $objectDefinition
     ) {
         $this->doctrine = $doctrine;
         $this->eventDispatcher = $eventDispatcher;
-        $this->class = $class;
+        $this->objectDefinition = $objectDefinition;
     }
 
     /**
@@ -36,7 +37,7 @@ class Manager implements ManagerInterface
      */
     public function getClass()
     {
-        return $this->class;
+        return $this->objectDefinition->getClass();
     }
 
     /**
@@ -44,7 +45,7 @@ class Manager implements ManagerInterface
      */
     protected function getManager()
     {
-        return $this->doctrine->getManagerForClass($this->class);
+        return $this->doctrine->getManagerForClass($this->getClass());
     }
 
     /**
@@ -52,8 +53,13 @@ class Manager implements ManagerInterface
      */
     protected function getRepository()
     {
-        return $this->doctrine->getManagerForClass($this->class)
-            ->getRepository($this->class);
+        return $this->doctrine->getManagerForClass($this->getClass())
+            ->getRepository($this->getClass());
+    }
+    
+    protected function throwUnsupportedMethodException()
+    {
+        throw new UnsupportedMethodException();
     }
 
     /**
@@ -62,14 +68,16 @@ class Manager implements ManagerInterface
      */
     public function search(Criteria $criteria)
     {
+        !$this->objectDefinition->canSearch() && $this->throwUnsupportedMethodException();
+
         $this->eventDispatcher->dispatch(RestEvents::PRE_SEARCH, new PreSearchEvent($criteria));
 
         /** @var \Doctrine\ORM\QueryBuilder $qb */
         $qb = $this->getManager()->createQueryBuilder('o');
         $qb->select($qb->expr()->count('o'))
-            ->from($this->class, 'o');
+            ->from($this->getClass(), 'o');
 
-        $metadata = $this->getManager()->getClassMetadata($this->class);
+        $metadata = $this->getManager()->getClassMetadata($this->getClass());
 
         foreach ($criteria as $key => $value) {
             if ($metadata->hasField($key)) {
@@ -113,6 +121,8 @@ class Manager implements ManagerInterface
      */
     public function create($object)
     {
+        !$this->objectDefinition->canCreate() && $this->throwUnsupportedMethodException();
+
         $em = $this->getManager();
 
         $this->eventDispatcher->dispatch(RestEvents::PRE_CREATE, new ObjectEvent($object));
@@ -144,6 +154,8 @@ class Manager implements ManagerInterface
      */
     public function update($object)
     {
+        !$this->objectDefinition->canUpdate() && $this->throwUnsupportedMethodException();
+
         $em = $this->getManager();
 
         $original = $this->retrieve(IdHelper::getId($object));
@@ -163,6 +175,8 @@ class Manager implements ManagerInterface
 
     public function partialUpdate($object)
     {
+        !$this->objectDefinition->canPartialUpdate() && $this->throwUnsupportedMethodException();
+
         /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getManager();
 
@@ -178,6 +192,8 @@ class Manager implements ManagerInterface
      */
     public function delete($id)
     {
+        !$this->objectDefinition->canDelete() && $this->throwUnsupportedMethodException();
+
         $object = $this->retrieve($id);
 
         $em = $this->getManager();

--- a/Object/ManagerFactory.php
+++ b/Object/ManagerFactory.php
@@ -40,12 +40,12 @@ class ManagerFactory implements ManagerFactoryInterface
      */
     public function create($resource)
     {
-        $class = $this->registry->getClass($resource);
+        $definition = $this->registry->get($resource);
 
         return new Manager(
             $this->doctrine,
             $this->eventDispatcher,
-            $class
+            $definition
         );
     }
 }

--- a/Object/Processor.php
+++ b/Object/Processor.php
@@ -70,8 +70,6 @@ class Processor
                 foreach ($value as $v) {
                     $this->processIds($v);
                 }
-            } else {
-                $this->processIds($value);
             }
         }
     }

--- a/Object/Registry.php
+++ b/Object/Registry.php
@@ -6,29 +6,31 @@ class Registry
     protected $classes = array();
 
     /**
-     * @param string $name
-     * @param string $class
+     * @param Definition $definition
      */
-    public function addClass($name, $class)
+    public function add(Definition $definition)
     {
-        if (!class_exists($class)) {
-            throw new \InvalidArgumentException(sprintf("Invalid class \"%s\"", $class));
+        if (!class_exists($definition->getClass())) {
+            throw new \InvalidArgumentException(sprintf(
+                "Invalid class \"%s\"",
+                $definition->getClass()
+            ));
         }
-        $this->classes[$name] = $class;
+        $this->classes[$definition->getName()] = $definition;
     }
 
-    public function getClasses()
+    public function all()
     {
         return $this->classes;
     }
 
     /**
      * @param string $name
-     * @return string
+     * @return Definition
      */
-    public function getClass($name)
+    public function get($name)
     {
-        if (!$this->hasClass($name)) {
+        if (!$this->has($name)) {
             throw new \InvalidArgumentException(sprintf("Invalid resource \"%s\"", $name));
         }
         return $this->classes[$name];
@@ -38,7 +40,7 @@ class Registry
      * @param string $name
      * @return bool
      */
-    public function hasClass($name)
+    public function has($name)
     {
         return array_key_exists($name, $this->classes);
     }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Authors
 
 * Stan Lemon <stosh1985@gmail.com>
 
+Changes
+-------
+
+Details about changes from version to version are stored in `CHANGELOG.md`
+
 Documentation
 -------------
 

--- a/Request/Handler.php
+++ b/Request/Handler.php
@@ -4,6 +4,7 @@ namespace Lemon\RestBundle\Request;
 
 use Lemon\RestBundle\Object\Exception\InvalidException;
 use Lemon\RestBundle\Object\Exception\NotFoundException;
+use Lemon\RestBundle\Object\Exception\UnsupportedMethodException;
 use Lemon\RestBundle\Object\ManagerFactoryInterface;
 use Lemon\RestBundle\Object\Envelope\EnvelopeFactory;
 use Lemon\RestBundle\Serializer\ConstructorFactory;
@@ -105,6 +106,12 @@ class Handler
             $response->setStatusCode(404);
             $data = array(
                 "code" => 404,
+                "message" => $e->getMessage(),
+            );
+        } catch (UnsupportedMethodException $e) {
+            $response->setStatusCode(405);
+            $data = array(
+                "code" => 405,
                 "message" => $e->getMessage(),
             );
         } catch (HttpException $e) {

--- a/Request/Handler.php
+++ b/Request/Handler.php
@@ -8,6 +8,7 @@ use Lemon\RestBundle\Object\Exception\UnsupportedMethodException;
 use Lemon\RestBundle\Object\ManagerFactoryInterface;
 use Lemon\RestBundle\Object\Envelope\EnvelopeFactory;
 use Lemon\RestBundle\Serializer\ConstructorFactory;
+use Lemon\RestBundle\Serializer\DeserializationContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -84,12 +85,16 @@ class Handler
         try {
             $manager = $this->managerFactory->create($resource);
 
+            $context = new DeserializationContext();
+            $context->enableMaxDepthChecks();
+
             $object = $this->serializer->create(
                 $request->isMethod('patch') ? 'doctrine' : 'default'
             )->deserialize(
                 $request->getContent(),
                 $manager->getClass(),
-                $format
+                $format,
+                $context
             );
 
             $data = $this->envelopeFactory->create(
@@ -126,7 +131,7 @@ class Handler
             $response->setStatusCode(500);
             $data = array(
                 "code" => 500,
-                "message" => $e->getMessage(),
+                "message" => $e->getMessage()
             );
         }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,3 +1,5 @@
+parameters:
+    jms_serializer.json_deserialization_visitor.class: Lemon\RestBundle\Serializer\LazyJsonDeserializationVisitor
 services:
     lemon_rest.resource_controller:
         class: Lemon\RestBundle\Controller\ResourceController
@@ -89,6 +91,12 @@ services:
         class: PhpCollection\Map
         scope: prototype
 
+    lemon_rest.serializer.object_constructor:
+        class: Lemon\RestBundle\Serializer\Construction\ToggleDoctrineObjectConstructor
+        arguments:
+            - @jms_serializer.doctrine_object_constructor
+            - @jms_serializer.unserialize_object_constructor
+
     lemon_rest.serializer.constructor_factory:
         class: Lemon\RestBundle\Serializer\ConstructorFactory
         arguments:
@@ -98,5 +106,5 @@ services:
             - @lemon_rest.serializer.collection
             - @jms_serializer.event_dispatcher
         calls:
-            - [ addObjectConstructor, ['default', @jms_serializer.unserialize_object_constructor] ]
+            - [ addObjectConstructor, ['default', @lemon_rest.serializer.object_constructor] ]
             - [ addObjectConstructor, ['doctrine', @jms_serializer.doctrine_object_constructor] ]

--- a/Serializer/Construction/ToggleDoctrineObjectConstructor.php
+++ b/Serializer/Construction/ToggleDoctrineObjectConstructor.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Lemon\RestBundle\Serializer\Construction;
+
+use JMS\Serializer\Construction\DoctrineObjectConstructor;
+use JMS\Serializer\Construction\ObjectConstructorInterface;
+use JMS\Serializer\Construction\UnserializeObjectConstructor;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\VisitorInterface;
+
+class ToggleDoctrineObjectConstructor implements ObjectConstructorInterface
+{
+    /** @var ObjectConstructorInterface */
+    protected $objectConstructor;
+    /** @var DoctrineObjectConstructor  */
+    protected $doctrineObjectConstructor;
+    /** @var UnserializeObjectConstructor  */
+    protected $unserializeObjectConstructor;
+
+    /**
+     * @param DoctrineObjectConstructor $doctrineObjectConstructor
+     * @param UnserializeObjectConstructor $unserializeObjectConstructor
+     */
+    public function __construct(
+        DoctrineObjectConstructor $doctrineObjectConstructor,
+        UnserializeObjectConstructor $unserializeObjectConstructor
+    ) {
+        $this->doctrineObjectConstructor = $doctrineObjectConstructor;
+        $this->unserializeObjectConstructor = $unserializeObjectConstructor;
+        $this->objectConstructor = $this->unserializeObjectConstructor;
+    }
+
+    public function useDoctrine()
+    {
+        $this->objectConstructor = $this->doctrineObjectConstructor;
+    }
+
+    public function isDoctrine()
+    {
+        return $this->objectConstructor === $this->doctrineObjectConstructor;
+    }
+
+    public function useDefault()
+    {
+        $this->objectConstructor = $this->unserializeObjectConstructor;
+    }
+
+    public function isDefault()
+    {
+        return $this->objectConstructor === $this->unserializeObjectConstructor;
+    }
+
+    public function construct(
+        VisitorInterface $visitor,
+        ClassMetadata $metadata,
+        $data,
+        array $type,
+        DeserializationContext $context
+    ) {
+        if ($context instanceof \Lemon\RestBundle\Serializer\DeserializationContext
+            && $context->shouldUseDoctrineConstructor())
+        {
+            $this->useDoctrine();
+        }
+
+        return $this->objectConstructor->construct(
+            $visitor,
+            $metadata,
+            $data,
+            $type,
+            $context
+        );
+    }
+}

--- a/Serializer/ConstructorFactory.php
+++ b/Serializer/ConstructorFactory.php
@@ -14,6 +14,8 @@ class ConstructorFactory
     protected $handlerRegistry;
     protected $eventDispatcher;
     protected $objectConstructorMap;
+    protected $serializationVisitors;
+    protected $deserializationVisitors;
 
     public function __construct(
         MetadataFactoryInterface $factory,

--- a/Serializer/DeserializationContext.php
+++ b/Serializer/DeserializationContext.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lemon\RestBundle\Serializer;
+
+use JMS\Serializer\DeserializationContext as BaseDeserializationContext;
+
+class DeserializationContext extends BaseDeserializationContext
+{
+    protected $useDoctrineConstructor = false;
+
+    public function useDoctrineConstructor()
+    {
+        $this->useDoctrineConstructor = true;
+    }
+
+    public function shouldUseDoctrineConstructor()
+    {
+        return $this->useDoctrineConstructor;
+    }
+}

--- a/Serializer/LazyJsonDeserializationVisitor.php
+++ b/Serializer/LazyJsonDeserializationVisitor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lemon\RestBundle\Serializer;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+class LazyJsonDeserializationVisitor extends JsonDeserializationVisitor
+{
+    public function visitProperty(PropertyMetadata $metadata, $data, Context $context)
+    {
+        $name = $this->namingStrategy->translateName($metadata);
+
+        $types = array('NULL', 'string', 'integer', 'boolean', 'double', 'float', 'array');
+
+        if (isset($data[$name]) && is_scalar($data[$name]) && !in_array($metadata->type['name'], $types)) {
+            /** @var DeserializationContext $context */
+            $context->useDoctrineConstructor();
+
+            $data[$name] = array(
+                'id' => $data[$name],
+            );
+        }
+
+        if (null === $data || ! array_key_exists($name, $data)) {
+            return;
+        }
+
+        if ( ! $metadata->type) {
+            throw new RuntimeException(sprintf('You must define a type for %s::$%s.', $metadata->reflection->class, $metadata->name));
+        }
+
+        $v = $data[$name] !== null ? $this->getNavigator()->accept($data[$name], $metadata->type, $context) : null;
+
+        if (null === $metadata->setter) {
+            $metadata->reflection->setValue($this->getCurrentObject(), $v);
+
+            return;
+        }
+
+        $this->getCurrentObject()->{$metadata->setter}($v);
+    }
+}

--- a/Tests/Controller/IndexControllerTest.php
+++ b/Tests/Controller/IndexControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lemon\RestBundle\Tests\Controller;
+
+use Doctrine\ORM\AbstractQuery;
+use Symfony\Component\HttpFoundation\Request;
+use Lemon\RestBundle\Tests\FunctionalTestCase;
+use Lemon\RestBundle\Event\RestEvents;
+use Lemon\RestBundle\Object\Criteria\DefaultCriteria;
+use Lemon\RestBundle\Object\Definition;
+use Lemon\RestBundle\Tests\Fixtures\Car;
+use Lemon\RestBundle\Tests\Fixtures\Tag;
+use Lemon\RestBundle\Tests\Fixtures\Person;
+use Lemon\RestBundle\Tests\Fixtures\FootballTeam;
+
+class IndexControllerTest extends FunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->controller = $this->container->get('lemon_rest.index_controller');
+    }
+
+    public function testIndex()
+    {
+        $request = $this->makeRequest('GET', '/', null);
+
+        /** @var \Symfony\Component\HttpFoundation\Response $response */
+        $response = $this->controller->indexAction($request);
+
+        $data = json_decode($response->getContent());
+        
+        $this->assertNotEmpty($data);
+        $this->assertEquals(
+            "http://localhost/person",
+            $data->person_url
+        );
+        $this->assertEquals(
+            "http://localhost/footballTeam",
+            $data->footballTeam_url
+        );
+    }
+}

--- a/Tests/Controller/IndexControllerTest.php
+++ b/Tests/Controller/IndexControllerTest.php
@@ -15,6 +15,11 @@ use Lemon\RestBundle\Tests\Fixtures\FootballTeam;
 
 class IndexControllerTest extends FunctionalTestCase
 {
+    /**
+     * @var \Lemon\RestBundle\Controller\IndexController
+     */
+    protected $controller;
+
     public function setUp()
     {
         parent::setUp();

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -15,6 +15,11 @@ use Lemon\RestBundle\Tests\Fixtures\FootballTeam;
 
 class ResourceControllerTest extends FunctionalTestCase
 {
+    /**
+     * @var \Lemon\RestBundle\Controller\ResourceController
+     */
+    protected $controller;
+
     public function setUp()
     {
         parent::setUp();

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -1062,4 +1062,42 @@ class ResourceControllerTest extends WebTestCase
         $this->assertEquals($footballTeam->conference, $data->conference);
         $this->assertTrue(!isset($data->league));
     }
+
+    public function testPostWithIdForObject()
+    {
+        $mother = new Person();
+        $mother->name = "Sharon Lemon";
+
+        $this->em->persist($mother);
+        $this->em->flush($mother);
+
+        $person = new Person();
+        $person->name = "Stan Lemon";
+        $person->mother = $mother;
+
+        $this->em->persist($person);
+        $this->em->flush($person);
+        $this->em->clear();
+
+        $request = $this->makeRequest(
+            'POST',
+            '/person/' . $person->id,
+            json_encode(array(
+                'name' => $person->name,
+                'mother' => $mother->id
+            ))
+        );
+
+        /** @var \Symfony\Component\HttpFoundation\Response $response */
+        $response = $this->controller->postAction($request, 'person', 1);
+
+        $refresh = $this->em->getRepository('Lemon\RestBundle\Tests\Fixtures\Person')->findOneBy(array(
+            'id' => $person->id
+        ));
+
+        $this->assertNotNull($refresh);
+        $this->assertNotNull($person->mother);
+        $this->assertEquals($mother->id, $person->mother->id);
+        $this->assertEquals($mother->name, $person->mother->name);
+    }
 }

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -3,94 +3,23 @@
 namespace Lemon\RestBundle\Tests\Controller;
 
 use Doctrine\ORM\AbstractQuery;
+use Symfony\Component\HttpFoundation\Request;
+use Lemon\RestBundle\Tests\FunctionalTestCase;
 use Lemon\RestBundle\Event\RestEvents;
 use Lemon\RestBundle\Object\Criteria\DefaultCriteria;
 use Lemon\RestBundle\Object\Definition;
 use Lemon\RestBundle\Tests\Fixtures\Car;
 use Lemon\RestBundle\Tests\Fixtures\Tag;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Doctrine\ORM\Tools\SchemaTool;
 use Lemon\RestBundle\Tests\Fixtures\Person;
 use Lemon\RestBundle\Tests\Fixtures\FootballTeam;
 
-class ResourceControllerTest extends WebTestCase
+class ResourceControllerTest extends FunctionalTestCase
 {
-    /**
-     * @var \Symfony\Bundle\FrameworkBundle\Client
-     */
-    protected $client;
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    protected $container;
-    /**
-     * @var \Doctrine\Bundle\DoctrineBundle\Registry
-     */
-    protected $doctrine;
-    /**
-     * @var \Doctrine\ORM\EntityManager
-     */
-    protected $em;
-    /**
-     * @var \JMS\Serializer\Serializer
-     */
-    protected $serializer;
-    /**
-     * @var \Lemon\RestBundle\Controller\ResourceController
-     */
-    protected $controller;
-
     public function setUp()
     {
-        $this->client = static::createClient();
-        $this->container = $this->client->getContainer();
-        $this->doctrine = $this->container->get('doctrine');
-        $this->em = $this->doctrine->getManager();
-        $this->serializer = $this->container->get('jms_serializer');
-
-        $schemaTool = new SchemaTool($this->em);
-        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
-
-        $this->doctrine->getConnection()->beginTransaction();
-
-        $registry = $this->container->get('lemon_rest.object_registry');
-        $registry->add(new Definition('person', 'Lemon\RestBundle\Tests\Fixtures\Person'));
-        $registry->add(new Definition('footballTeam', 'Lemon\RestBundle\Tests\Fixtures\FootballTeam'));
+        parent::setUp();
 
         $this->controller = $this->container->get('lemon_rest.resource_controller');
-    }
-
-    protected static function getKernelClass()
-    {
-        return 'Lemon\RestBundle\Tests\TestKernel';
-    }
-
-    public function tearDown()
-    {
-        $this->doctrine->getConnection()->rollback();
-    }
-
-    /**
-     * @param string $method
-     * @param string $uri
-     * @param string|null $content
-     * @return Request
-     */
-    protected function makeRequest($method, $uri, $content = null, $parameters = array(), $server = array())
-    {
-        $request = Request::create(
-            $uri,
-            $method,
-            $parameters,
-            $cookies = array(),
-            $files = array(),
-            $server = array_merge(array(
-                'HTTP_ACCEPT' => 'application/json',
-            ), $server),
-            $content
-        );
-        return $request;
     }
 
     public function testListAction()

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -5,6 +5,7 @@ namespace Lemon\RestBundle\Tests\Controller;
 use Doctrine\ORM\AbstractQuery;
 use Lemon\RestBundle\Event\RestEvents;
 use Lemon\RestBundle\Object\Criteria\DefaultCriteria;
+use Lemon\RestBundle\Object\Definition;
 use Lemon\RestBundle\Tests\Fixtures\Car;
 use Lemon\RestBundle\Tests\Fixtures\Tag;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,8 +55,8 @@ class ResourceControllerTest extends WebTestCase
         $this->doctrine->getConnection()->beginTransaction();
 
         $registry = $this->container->get('lemon_rest.object_registry');
-        $registry->addClass('person', 'Lemon\RestBundle\Tests\Fixtures\Person');
-        $registry->addClass('footballTeam', 'Lemon\RestBundle\Tests\Fixtures\FootballTeam');
+        $registry->add(new Definition('person', 'Lemon\RestBundle\Tests\Fixtures\Person'));
+        $registry->add(new Definition('footballTeam', 'Lemon\RestBundle\Tests\Fixtures\FootballTeam'));
 
         $this->controller = $this->container->get('lemon_rest.resource_controller');
     }

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -1073,14 +1073,13 @@ class ResourceControllerTest extends WebTestCase
 
         $person = new Person();
         $person->name = "Stan Lemon";
-        $person->mother = $mother;
 
         $this->em->persist($person);
         $this->em->flush($person);
         $this->em->clear();
 
         $request = $this->makeRequest(
-            'POST',
+            'PUT',
             '/person/' . $person->id,
             json_encode(array(
                 'name' => $person->name,
@@ -1089,15 +1088,15 @@ class ResourceControllerTest extends WebTestCase
         );
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
-        $response = $this->controller->postAction($request, 'person', 1);
+        $response = $this->controller->putAction($request, 'person', $person->id);
 
         $refresh = $this->em->getRepository('Lemon\RestBundle\Tests\Fixtures\Person')->findOneBy(array(
             'id' => $person->id
         ));
 
         $this->assertNotNull($refresh);
-        $this->assertNotNull($person->mother);
-        $this->assertEquals($mother->id, $person->mother->id);
-        $this->assertEquals($mother->name, $person->mother->name);
+        $this->assertNotNull($refresh->mother);
+        $this->assertEquals($mother->id, $refresh->mother->id);
+        $this->assertEquals($mother->name, $refresh->mother->name);
     }
 }

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -1003,13 +1003,13 @@ class ResourceControllerTest extends FunctionalTestCase
         $mother->name = "Sharon Lemon";
 
         $this->em->persist($mother);
-        $this->em->flush($mother);
 
         $person = new Person();
         $person->name = "Stan Lemon";
 
         $this->em->persist($person);
-        $this->em->flush($person);
+
+        $this->em->flush();
         $this->em->clear();
 
         $request = $this->makeRequest(

--- a/Tests/FunctionalTestCase.php
+++ b/Tests/FunctionalTestCase.php
@@ -29,10 +29,6 @@ abstract class FunctionalTestCase extends WebTestCase
      * @var \JMS\Serializer\Serializer
      */
     protected $serializer;
-    /**
-     * @var \Lemon\RestBundle\Controller\ResourceController
-     */
-    protected $controller;
 
     public function setUp()
     {

--- a/Tests/FunctionalTestCase.php
+++ b/Tests/FunctionalTestCase.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Lemon\RestBundle\Tests;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Doctrine\ORM\Tools\SchemaTool;
+use Lemon\RestBundle\Object\Definition;
+
+abstract class FunctionalTestCase extends WebTestCase
+{
+    /**
+     * @var \Symfony\Bundle\FrameworkBundle\Client
+     */
+    protected $client;
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+    /**
+     * @var \Doctrine\Bundle\DoctrineBundle\Registry
+     */
+    protected $doctrine;
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $em;
+    /**
+     * @var \JMS\Serializer\Serializer
+     */
+    protected $serializer;
+    /**
+     * @var \Lemon\RestBundle\Controller\ResourceController
+     */
+    protected $controller;
+
+    public function setUp()
+    {
+        $this->client = static::createClient();
+        $this->container = $this->client->getContainer();
+        $this->doctrine = $this->container->get('doctrine');
+        $this->em = $this->doctrine->getManager();
+        $this->serializer = $this->container->get('jms_serializer');
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+
+        $this->doctrine->getConnection()->beginTransaction();
+
+        $registry = $this->container->get('lemon_rest.object_registry');
+        $registry->add(new Definition('person', 'Lemon\RestBundle\Tests\Fixtures\Person'));
+        $registry->add(new Definition('footballTeam', 'Lemon\RestBundle\Tests\Fixtures\FootballTeam'));
+    }
+
+    protected static function getKernelClass()
+    {
+        return 'Lemon\RestBundle\Tests\TestKernel';
+    }
+
+    public function tearDown()
+    {
+        $this->doctrine->getConnection()->rollback();
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param string|null $content
+     * @return Request
+     */
+    protected function makeRequest($method, $uri, $content = null, $parameters = array(), $server = array())
+    {
+        $request = Request::create(
+            $uri,
+            $method,
+            $parameters,
+            $cookies = array(),
+            $files = array(),
+            $server = array_merge(array(
+                'HTTP_ACCEPT' => 'application/json',
+            ), $server),
+            $content
+        );
+        return $request;
+    }
+}

--- a/Tests/Object/ManagerFactoryTest.php
+++ b/Tests/Object/ManagerFactoryTest.php
@@ -2,7 +2,8 @@
 namespace Lemon\RestBundle\Tests\Object;
 
 use Lemon\RestBundle\Object\ManagerFactory;
-use \Lemon\RestBundle\Object\Registry;
+use Lemon\RestBundle\Object\Registry;
+use Lemon\RestBundle\Object\Definition;
 
 /**
  * @coversDefaultClass \Lemon\RestBundle\Object\ManagerFactory
@@ -16,7 +17,7 @@ class ManagerFactoryTest extends \Xpmock\TestCase
         $doctrine = $this->mock('Doctrine\Bundle\DoctrineBundle\Registry')->new();
 
         $registry = new Registry();
-        $registry->addClass('person', 'Lemon\RestBundle\Tests\Fixtures\Person');
+        $registry->add(new Definition('person', 'Lemon\RestBundle\Tests\Fixtures\Person'));
 
         $managerFactory = new ManagerFactory(
             $registry,

--- a/Tests/Object/RegistryTest.php
+++ b/Tests/Object/RegistryTest.php
@@ -2,6 +2,7 @@
 namespace Lemon\RestBundle\Tests\Object;
 
 use Lemon\RestBundle\Object\Registry;
+use Lemon\RestBundle\Object\Definition;
 
 /**
  * @coversDefaultClass \Lemon\RestBundle\Object\Registry
@@ -9,48 +10,50 @@ use Lemon\RestBundle\Object\Registry;
 class RegistryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers ::addClass()
-     * @covers ::hasClass()
-     * @covers ::getClass()
-     * @covers ::getClasses()
+     * @covers ::add()
+     * @covers ::has()
+     * @covers ::get()
+     * @covers ::all()
      */
     public function testAddClass()
     {
-        $registry = new Registry();
-        $registry->addClass('person', '\Lemon\RestBundle\Tests\Fixtures\Person');
+        $definition = new Definition('person', '\Lemon\RestBundle\Tests\Fixtures\Person');
 
-        $this->assertTrue($registry->hasClass('person'));
+        $registry = new Registry();
+        $registry->add($definition);
+
+        $this->assertTrue($registry->has('person'));
         $this->assertEquals(
             '\Lemon\RestBundle\Tests\Fixtures\Person',
-            $registry->getClass('person')
+            $registry->get('person')->getClass()
         );
         $this->assertEquals(
             array(
-                'person' => '\Lemon\RestBundle\Tests\Fixtures\Person'
+                'person' => $definition
             ),
-            $registry->getClasses()
+            $registry->all()
         );
     }
 
     /**
-     * @covers ::addClass()
+     * @covers ::add()
      */
     public function testAddClassDoesNotExist()
     {
         $this->setExpectedException('\InvalidArgumentException');
 
         $registry = new Registry();
-        $registry->addClass('foo', '\foo\bar');
+        $registry->add(new Definition('foo', '\foo\bar'));
     }
 
     /**
-     * @covers ::getClass()
+     * @covers ::get()
      */
     public function testGetClassNotInRegistry()
     {
         $this->setExpectedException('\InvalidArgumentException');
 
         $registry = new Registry();
-        $registry->getClass('\foo\bar');
+        $registry->get('\foo\bar');
     }
 }

--- a/Tests/config/config.yml
+++ b/Tests/config/config.yml
@@ -15,10 +15,9 @@ monolog:
     handlers:
         stdout:
             type:  stream
-            path:  "php://stdout"
+            path:  "php://temp"
             level: debug
             channels: app
-            formatter: monolog_line_formatter
 
 doctrine:
     dbal:
@@ -39,8 +38,3 @@ doctrine:
                         type: annotation
                         prefix: Lemon\RestBundle\Tests\Fixtures\
                         dir: %kernel.root_dir%/Fixtures/
-
-services:
-    monolog_line_formatter:
-        class: Monolog\Formatter\LineFormatter
-        arguments: [null, null, true, false]


### PR DESCRIPTION
* Default to plural resource names
* Allow for mapping of a directory of entities
* Allow for fine grain configuration of method types for an object, in other words you can now enable 'post' for an object and disable 'delete'
* Added a first class definition object, this can be used to store additional metadata in the future
* Added support for posting an id to a relation to load the mapped relation, in other words a ```comment``` can be posted with a numerical value for property ```post``` and this will become the appropriate ```Post``` instance.