### PR TITLE
[RFR] Make logger optional

### DIFF
--- a/Request/Handler.php
+++ b/Request/Handler.php
@@ -10,6 +10,7 @@ use Lemon\RestBundle\Object\Envelope\EnvelopeFactory;
 use Lemon\RestBundle\Serializer\ConstructorFactory;
 use Lemon\RestBundle\Serializer\DeserializationContext;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -54,13 +55,13 @@ class Handler
         EnvelopeFactory $envelopeFactory,
         ConstructorFactory $serializer,
         FormatNegotiator $negotiator,
-        LoggerInterface $logger
+        LoggerInterface $logger = null
     ) {
         $this->managerFactory = $managerFactory;
         $this->envelopeFactory = $envelopeFactory;
         $this->serializer = $serializer;
         $this->negotiator = $negotiator;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,7 +26,7 @@ services:
             - @lemon_rest.object_envelope_factory
             - @lemon_rest.serializer.constructor_factory
             - @lemon_rest.format_negotiator
-            - @logger
+            - @?logger
 
     lemon_rest.format_negotiator:
         class: Negotiation\FormatNegotiator


### PR DESCRIPTION
This PR makes the logger optional. This is especially useful for testing purposes, as you don't have to mock it, or in the case of the [NgAdminGeneratorBundle](https://travis-ci.org/marmelab/NgAdminGeneratorBundle/jobs/60567418#L407) as you don't have to embed Monolog dependency.