### PR TITLE
Checks the PHP version for JSON_PRETTY_PRINT

### DIFF
--- a/DependencyInjection/Extension.php
+++ b/DependencyInjection/Extension.php
@@ -26,7 +26,7 @@ class Extension extends BaseExtension
         $container->setParameter('lemon_rest_formats', $config['formats']);
 
         // Force pretty print for JMS on, no one likes their JSON ugly
-        if (defined('JSON_PRETTY_PRINT')) {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
             $container->setParameter(
                 'jms_serializer.json_serialization_visitor.options',
                 $container->getParameter('jms_serializer.json_serialization_visitor.options') | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES


### PR DESCRIPTION
PHPUnit declares the constant `JSON_PRETTY_PRINT` but not `JSON_UNESCAPED_SLASHES`.
The pretty feature only works on PHP 5.4+

https://github.com/sebastianbergmann/phpunit/blob/4.7.3/src/Util/Log/JSON.php#L11