### PR TITLE
Fix negotiation version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/doctrine-bundle": "~1.2",
         "jms/serializer": "~0.14",
         "jms/serializer-bundle": "~0.13",
-        "willdurand/negotiation": ">=1.3.2"
+        "willdurand/negotiation": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/doctrine-bundle": "~1.2",
         "jms/serializer": "~0.14",
         "jms/serializer-bundle": "~0.13",
-        "willdurand/negotiation": "1.*"
+        "willdurand/negotiation": ">=1.3.2 <2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7",


### PR DESCRIPTION
New major version of willdurand/negociation (>=2.0) comes with BC breaks. I fixed version to 1.*.