### PR TITLE
Class validation bug with not managed entity.

### DIFF
--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -131,13 +131,8 @@ class ResourceController
             $request,
             $this->response,
             $resource,
-            function (ManagerInterface $manager, $object) use ($id) {
-                $reflection = new \ReflectionObject($object);
-                $property = $reflection->getProperty('id');
-                $property->setAccessible(true);
-                $property->setValue($object, $id);
-
-                $manager->update($object);
+            function (ManagerInterface $manager, $object) {
+                $manager->partialUpdate($object);
 
                 return $object;
             }
@@ -156,7 +151,7 @@ class ResourceController
             $request,
             $this->response,
             $resource,
-            function (ManagerInterface $manager, $object) use ($id) {
+            function (ManagerInterface $manager, $object) {
                 $manager->partialUpdate($object);
 
                 return $object;

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -141,8 +141,9 @@ class ResourceController
 
     /**
      * @param Request $request
-     * @param string $resource
-     * @param int $id
+     * @param string  $resource
+     * @param int     $id
+     *
      * @return Response
      */
     public function patchAction(Request $request, $resource, $id)
@@ -161,8 +162,9 @@ class ResourceController
 
     /**
      * @param Request $request
-     * @param string $resource
-     * @param int $id
+     * @param string  $resource
+     * @param int     $id
+     *
      * @return Response
      */
     public function deleteAction(Request $request, $resource, $id)
@@ -174,13 +176,22 @@ class ResourceController
             $this->response,
             $resource,
             function (ManagerInterface $manager) use ($response, $id) {
-                $response->setStatusCode(204);
+                $response->setStatusCode(200);
 
-                $manager->delete($id);
+                $object = $manager->delete($id);
+
+                return $object;
             }
         );
     }
 
+    /**
+     * @param Request $request
+     * @param string  $resource
+     * @param int     $id
+     *
+     * @return Response
+     */
     public function optionsAction(Request $request, $resource, $id = null)
     {
         return $this->handler->options(

--- a/Object/Manager.php
+++ b/Object/Manager.php
@@ -145,7 +145,9 @@ class Manager implements ManagerInterface
 
         $original = $this->retrieve(IdHelper::getId($object));
 
-        $object = $em->merge($object);
+        if ($em->contains($object) === false) {
+            $object = $em->merge($object);
+        }
 
         $this->eventDispatcher->dispatch(RestEvents::PRE_UPDATE, new ObjectEvent($object, $original));
 
@@ -163,7 +165,9 @@ class Manager implements ManagerInterface
 
         $em = $this->getManager();
 
-        $object = $em->merge($object);
+        if ($em->contains($object) === false) {
+            $object = $em->merge($object);
+        }
 
         $em->flush();
         $em->refresh($object);
@@ -182,7 +186,9 @@ class Manager implements ManagerInterface
 
         $em = $this->getManager();
 
-        $object = $em->merge($object);
+        if ($em->contains($object) === false) {
+            $object = $em->merge($object);
+        }
 
         $this->eventDispatcher->dispatch(RestEvents::PRE_DELETE, new ObjectEvent($object));
 

--- a/Object/Manager.php
+++ b/Object/Manager.php
@@ -57,7 +57,7 @@ class Manager implements ManagerInterface
     {
         $manager = $this->getManager();
         $repository = $manager->getRepository($this->getClass());
-        
+
         if ($repository instanceof Repository) {
             return $repository;
         }
@@ -65,14 +65,14 @@ class Manager implements ManagerInterface
         if ($manager instanceof \Doctrine\ORM\EntityManager) {
             return new OrmRepositoryWrapper($repository);
         }
-        
+
         if ($manager instanceof \Doctrine\ODM\MongoDB\DocumentManager) {
             return new MongoRepositoryWrapper($repository);
         }
-        
+
         throw new \RuntimeException("I have no idea what to do with this repository class!");
     }
-    
+
     protected function throwUnsupportedMethodException()
     {
         throw new UnsupportedMethodException();
@@ -92,7 +92,7 @@ class Manager implements ManagerInterface
 
         $total = $repository->count($criteria);
         $objects = $repository->search($criteria);
-        
+
         $results = new SearchResults($objects, $total);
 
         $this->eventDispatcher->dispatch(RestEvents::POST_SEARCH, new PostSearchEvent($results));
@@ -145,11 +145,10 @@ class Manager implements ManagerInterface
 
         $original = $this->retrieve(IdHelper::getId($object));
 
-        $this->eventDispatcher->dispatch(RestEvents::PRE_UPDATE, new ObjectEvent($object, $original));
-
         $object = $em->merge($object);
 
-        $em->persist($object);
+        $this->eventDispatcher->dispatch(RestEvents::PRE_UPDATE, new ObjectEvent($object, $original));
+
         $em->flush();
         $em->refresh($object);
 
@@ -164,7 +163,8 @@ class Manager implements ManagerInterface
 
         $em = $this->getManager();
 
-        $em->persist($object);
+        $object = $em->merge($object);
+
         $em->flush();
         $em->refresh($object);
 
@@ -181,6 +181,8 @@ class Manager implements ManagerInterface
         $object = $this->retrieve($id);
 
         $em = $this->getManager();
+
+        $object = $em->merge($object);
 
         $this->eventDispatcher->dispatch(RestEvents::PRE_DELETE, new ObjectEvent($object));
 

--- a/Object/Manager.php
+++ b/Object/Manager.php
@@ -13,6 +13,11 @@ use Lemon\RestBundle\Object\Repository\OrmRepositoryWrapper;
 use Lemon\RestBundle\Object\Repository\MongoRepositoryWrapper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+/**
+ * Class Manager
+ *
+ * @package Lemon\RestBundle\Object
+ */
 class Manager implements ManagerInterface
 {
     protected $doctrine;
@@ -73,6 +78,9 @@ class Manager implements ManagerInterface
         throw new \RuntimeException("I have no idea what to do with this repository class!");
     }
 
+    /**
+     * @throws UnsupportedMethodException
+     */
     protected function throwUnsupportedMethodException()
     {
         throw new UnsupportedMethodException();
@@ -80,6 +88,7 @@ class Manager implements ManagerInterface
 
     /**
      * @param Criteria $criteria
+     *
      * @return SearchResults
      */
     public function search(Criteria $criteria)
@@ -101,7 +110,8 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * @param object $object
+     * @param mixed $object
+     *
      * @return mixed
      */
     public function create($object)
@@ -123,7 +133,8 @@ class Manager implements ManagerInterface
 
     /**
      * @param integer $id
-     * @return object
+     *
+     * @return mixed
      */
     public function retrieve($id)
     {
@@ -134,8 +145,9 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * @param object $object
-     * @return object
+     * @param mixed $object
+     *
+     * @return mixed
      */
     public function update($object)
     {
@@ -159,6 +171,11 @@ class Manager implements ManagerInterface
         return $object;
     }
 
+    /**
+     * @param mixed $object
+     *
+     * @return mixed
+     */
     public function partialUpdate($object)
     {
         !$this->objectDefinition->canPartialUpdate() && $this->throwUnsupportedMethodException();
@@ -176,7 +193,9 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * @param integer $id
+     * @param int $id
+     *
+     * @return mixed
      */
     public function delete($id)
     {
@@ -196,10 +215,13 @@ class Manager implements ManagerInterface
         $em->flush();
 
         $this->eventDispatcher->dispatch(RestEvents::POST_DELETE, new ObjectEvent($object));
+
+        return $object;
     }
 
     /**
      * @param bool $isResource
+     *
      * @return array
      */
     public function getOptions($isResource = false)

--- a/Object/Repository/OrmRepositoryWrapper.php
+++ b/Object/Repository/OrmRepositoryWrapper.php
@@ -119,6 +119,15 @@ class OrmRepositoryWrapper implements Repository
                                     $qb->andWhere('e.' . $fieldName . ' = :' . $fieldName);
                                     $qb->setParameter($fieldName, in_array($value, ['1', 'true']));
                                 }
+                            } elseif (
+                                ($fieldMetaData['type'] === 'date')
+                                || ($fieldMetaData['type'] === 'datetime')
+                                || ($fieldMetaData['type'] === 'datetimez')
+                            ) {
+                                $date = new \DateTime($value);
+
+                                $qb->andWhere('e.'.$fieldName.' LIKE :'.$fieldName);
+                                $qb->setParameter($fieldName, sprintf('%s%%', $date->format('Y-m-d')));
                             } else {
                                 $qb->andWhere('e.' . $fieldName . ' = :' . $fieldName);
                                 $qb->setParameter($fieldName, $value);

--- a/Object/Validator.php
+++ b/Object/Validator.php
@@ -35,7 +35,7 @@ class Validator
                 $flattenedErros[$error->getPropertyPath()] = $error->getMessage();
             }
 
-            throw new InvalidException("Object is invalid", $flattenedErros);
+            throw new InvalidException("An error occured.\n".implode(" \n", $flattenedErros), $flattenedErros);
         }
     }
 }

--- a/Request/Handler.php
+++ b/Request/Handler.php
@@ -75,7 +75,7 @@ class Handler
         $accept = $this->negotiator->getBest($request->headers->get('Accept'));
 
         $format = $this->negotiator->getFormat($accept->getValue());
-        
+
         if ($format == 'html') {
             $format = 'json';
         }
@@ -93,7 +93,7 @@ class Handler
 
             if (!empty($content)) {
                 $object = $this->serializer->create(
-                    $request->isMethod('patch') ? 'doctrine' : 'default'
+                    ($request->isMethod('put') || $request->isMethod('patch')) ? 'doctrine' : 'default'
                 )->deserialize(
                     $request->getContent(),
                     $manager->getClass(),

--- a/Request/Handler.php
+++ b/Request/Handler.php
@@ -92,14 +92,16 @@ class Handler
             $content = $request->getContent();
 
             if (!empty($content)) {
-                $object = $this->serializer->create(
-                    ($request->isMethod('put') || $request->isMethod('patch')) ? 'doctrine' : 'default'
-                )->deserialize(
-                    $request->getContent(),
-                    $manager->getClass(),
-                    $format,
-                    $context
-                );
+                $object = $this
+                    ->serializer
+                    ->create('doctrine')
+                    ->deserialize(
+                        $request->getContent(),
+                        $manager->getClass(),
+                        $format,
+                        $context
+                    )
+                ;
             }
 
             $data = $this->envelopeFactory->create(


### PR DESCRIPTION
Currently class validation [UniqueEntity](http://symfony.com/doc/current/reference/constraints/UniqueEntity.html) triggers on update where it shouldn't because the object are merged after the preUpdate event used for the validation.

Plus we should only persist on create and merge (if needed) in the other cases.